### PR TITLE
Se arreglan 'typos' en about.html y [Kotlin/data-types]

### DIFF
--- a/about.html
+++ b/about.html
@@ -56,7 +56,7 @@
         <p>Quienes quieran ser colaboradores de este sitio, pueden añadir en este espacio su nombre y url</p>
           <p>Un agradecimiento especial a quienes contribuyen en este sitio, haciendolo crecer:</p>
           <ul>
-            <li><a href="https://github.com/LazarusPolar">Jose Almaraz (LazarusPolar)</li>
+              <li><a href="https://github.com/LazarusPolar">Jose Almaraz (LazarusPolar)</a></li>
             <li>El próximo puedes ser tu. Contribuye con este sitio :) </li>
           </ul>          
         <h4>Licencia</h4>

--- a/langs/Kotlin/data-types
+++ b/langs/Kotlin/data-types
@@ -3,7 +3,7 @@ var b: Short = 128 // Valores entre -32768 y 32767
 var c: Int = 32768 // Valores entre -2,147,483,648 y 2,147,483,647
 var d: Long = 123123123123 // Valores entre -9,223,372,036,854,775,808 y 9,223,372,036,854,775,807
 var e: Float = 1.15f // Valores con punto decimal
-var f: Doouble = 1.15524212312 // Valores con punto decimal y el doble de precision que los valores "Float"
+var f: Double = 1.15524212312 // Valores con punto decimal y el doble de precision que los valores "Float"
 var g: Boolean = true // Datos booleanos con valores "true" o "false"
 var h: Char = 'z' // Dato de tipo caracter
 


### PR DESCRIPTION
- Se hace un arreglo en el archivo about.html en donde faltaba agregar una etiqueta
- Se hace un arreglo a los comentarios del archivo 'data-types' de Kotlin en donde se encontró un "typo"